### PR TITLE
Rot13 rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Language/Rust/rot13/Cargo.toml
+++ b/Language/Rust/rot13/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rot13"
+version = "0.1.0"
+authors = ["Michel Martinez <michel.martinez@linx.com.br>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/Language/Rust/rot13/Cargo.toml
+++ b/Language/Rust/rot13/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rot13"
 version = "0.1.0"
-authors = ["Michel Martinez <michel.martinez@linx.com.br>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Language/Rust/rot13/src/lib.rs
+++ b/Language/Rust/rot13/src/lib.rs
@@ -1,0 +1,19 @@
+fn cp13(c: char) -> char {
+    ((c as u8) + 13) as char
+}
+
+fn cm13(c: char) -> char {
+    ((c as u8) - 13) as char
+}
+
+pub fn rot13(value: &str) -> String {
+    value.chars().map(|c| {
+        match c {
+            'a' ..= 'm' => cp13(c),
+            'A' ..= 'M' => cp13(c),
+            'n' ..= 'z' => cm13(c),
+            'N' ..= 'Z' => cm13(c),
+            _ => c
+        }
+    }).collect()
+}

--- a/Language/Rust/rot13/src/lib.rs
+++ b/Language/Rust/rot13/src/lib.rs
@@ -1,3 +1,9 @@
+// ROT13 ("rotate by 13 places", sometimes hyphenated ROT-13)
+// is a simple letter substitution cipher that replaces a letter
+// with the 13th letter after it, in the alphabet.
+//
+// lib to use:
+
 fn cp13(c: char) -> char {
     ((c as u8) + 13) as char
 }

--- a/Language/Rust/rot13/src/lib.rs
+++ b/Language/Rust/rot13/src/lib.rs
@@ -4,15 +4,18 @@
 //
 // lib to use:
 
+// sum 13 to char and return it
 fn cp13(c: char) -> char {
     ((c as u8) + 13) as char
 }
 
+// sub 13 from the char and return it
 fn cm13(c: char) -> char {
     ((c as u8) - 13) as char
 }
 
 pub fn rot13(value: &str) -> String {
+    // change chars and return the string
     value.chars().map(|c| {
         match c {
             'a' ..= 'm' => cp13(c),

--- a/Language/Rust/rot13/tests/rot13.rs
+++ b/Language/Rust/rot13/tests/rot13.rs
@@ -1,0 +1,18 @@
+use rot13;
+
+#[test]
+fn test_rot13_numbers() {
+    assert_eq!("Ebg13", rot13::rot13("Rot13"));
+}
+
+
+#[test]
+fn test_rot13_space() {
+    assert_eq!("Zvpury Znegvarm", rot13::rot13("Michel Martinez"));
+}
+
+
+#[test]
+fn test_rot13_special_characters() {
+    assert_eq!("Ehfg! @Ebg !# 31", rot13::rot13("Rust! @Rot !# 31"));
+}

--- a/Language/Rust/rot13/tests/rot13.rs
+++ b/Language/Rust/rot13/tests/rot13.rs
@@ -1,3 +1,9 @@
+// ROT13 ("rotate by 13 places", sometimes hyphenated ROT-13)
+// is a simple letter substitution cipher that replaces a letter
+// with the 13th letter after it, in the alphabet.
+//
+// examples of tests:
+
 use rot13;
 
 #[test]


### PR DESCRIPTION
# Description

This program (lib) make the pseudo encryption 'rot13' on strings, using Rust.
ROT13 ("rotate by 13 places", sometimes hyphenated ROT-13) is a simple letter substitution cipher that replaces a letter with the 13th letter after it, in the alphabet.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added my code in its respective language folder.
- [x] I have mentioned a short description about the code at the beginning of the program.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have not deleted any files that already exist in the repository.

This is for the issue #3 
